### PR TITLE
Added args and kwargs to classview functions

### DIFF
--- a/django_pdfkit/tests/settings.py
+++ b/django_pdfkit/tests/settings.py
@@ -20,6 +20,8 @@ INSTALLED_APPS = [
 
 STATIC_URL = '/static/'
 
+MEDIA_URL = '/media/'
+
 SECRET_KEY = 's3cr3t'
 
 # Django replaces this, but it still wants it. *shrugs*

--- a/django_pdfkit/views.py
+++ b/django_pdfkit/views.py
@@ -112,6 +112,5 @@ class PDFView(TemplateView):
         with override_settings(STATIC_URL=static_url, MEDIA_URL=media_url):
             template = loader.get_template(self.template_name)
             context = self.get_context_data(*args, **kwargs)
-            request_context = RequestContext(self.request, context)
-            html = template.render(request_context)
+            html = template.render(context)
             return html

--- a/django_pdfkit/views.py
+++ b/django_pdfkit/views.py
@@ -37,12 +37,12 @@ class PDFView(TemplateView):
         """
         if 'html' in request.GET:
             # Output HTML
-            content = self.render_html()
+            content = self.render_html(*args, **kwargs)
             return HttpResponse(content)
 
         else:
             # Output PDF
-            content = self.render_pdf()
+            content = self.render_pdf(*args, **kwargs)
 
             response = HttpResponse(content, content_type='application/pdf')
 
@@ -53,13 +53,13 @@ class PDFView(TemplateView):
 
             return response
 
-    def render_pdf(self):
+    def render_pdf(self, *args, **kwargs):
         """
         Render the PDF and returns as bytes.
 
         :rtype: bytes
         """
-        html = self.render_html()
+        html = self.render_html(*args, **kwargs)
 
         options = self.get_pdfkit_options()
         if 'debug' in self.request.GET and settings.DEBUG:
@@ -100,7 +100,7 @@ class PDFView(TemplateView):
         else:
             return self.filename
 
-    def render_html(self):
+    def render_html(self, *args, **kwargs):
         """
         Renders the template.
 
@@ -109,7 +109,7 @@ class PDFView(TemplateView):
         static_url = '%s://%s%s' % (self.request.scheme, self.request.get_host(), settings.STATIC_URL)
         with override_settings(STATIC_URL=static_url):
             template = loader.get_template(self.template_name)
-            context = self.get_context_data(**{})
+            context = self.get_context_data(*args, **kwargs)
             request_context = RequestContext(self.request, context)
             html = template.render(request_context)
             return html

--- a/django_pdfkit/views.py
+++ b/django_pdfkit/views.py
@@ -107,7 +107,9 @@ class PDFView(TemplateView):
         :rtype: str
         """
         static_url = '%s://%s%s' % (self.request.scheme, self.request.get_host(), settings.STATIC_URL)
-        with override_settings(STATIC_URL=static_url):
+        media_url = '%s://%s%s' % (self.request.scheme, self.request.get_host(), settings.MEDIA_URL)
+
+        with override_settings(STATIC_URL=static_url, MEDIA_URL=media_url):
             template = loader.get_template(self.template_name)
             context = self.get_context_data(*args, **kwargs)
             request_context = RequestContext(self.request, context)

--- a/django_pdfkit/views.py
+++ b/django_pdfkit/views.py
@@ -12,7 +12,6 @@ from os.path import basename, splitext
 
 from django.conf import settings
 from django.http import HttpResponse
-from django.template import RequestContext
 from django.template import loader
 from django.test import override_settings
 from django.views.generic import TemplateView


### PR DESCRIPTION
Hi, you may consider this changes useful. I've added *args and **kwargs to render_html and render_pdf in order have them available in get_context_data. This is something I needed in order to override get_context_data and retrieve an specific instance of a model from url kwargs (eg.: an id or uuid).