### PR TITLE
Run tests on newer versions of python and django.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,6 @@ language: python
 matrix:
   include:
     # See https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-can-i-use-with-django
-    # Python 2.7
-    - python: 2.7
-      env: TOXENV=py27-django18
-    - python: 2.7
-      env: TOXENV=py27-django19
-    - python: 2.7
-      env: TOXENV=py27-django110
-    - python: 2.7
-      env: TOXENV=py27-django111
-
-    # Python 3.4
-    - python: 3.4
-      env: TOXENV=py34-django18
-    - python: 3.4
-      env: TOXENV=py34-django19
-    - python: 3.4
-      env: TOXENV=py34-django110
-    - python: 3.4
-      env: TOXENV=py34-django111
-
     # Python 3.5
     - python: 3.5
       env: TOXENV=py35-django18
@@ -31,20 +11,100 @@ matrix:
       env: TOXENV=py35-django110
     - python: 3.5
       env: TOXENV=py35-django111
+    - python: 3.5
+      env: TOXENV=py35-django20
+    - python: 3.5
+      env: TOXENV=py35-django21
+    - python: 3.5
+      env: TOXENV=py35-django22
 
     # Python 3.6
     - python: 3.6
+      env: TOXENV=py36-django18
+    - python: 3.6
+      env: TOXENV=py36-django19
+    - python: 3.6
+      env: TOXENV=py36-django110
+    - python: 3.6
       env: TOXENV=py36-django111
+    - python: 3.6
+      env: TOXENV=py36-django20
+    - python: 3.6
+      env: TOXENV=py36-django21
+    - python: 3.6
+      env: TOXENV=py36-django22
+    - python: 3.6
+      env: TOXENV=py36-django30
 
-    # pypy
+    # Python 3.7
+    - python: 3.7
+      env: TOXENV=py36-django18
+    - python: 3.7
+      env: TOXENV=py36-django19
+    - python: 3.7
+      env: TOXENV=py36-django110
+    - python: 3.7
+      env: TOXENV=py36-django111
+    - python: 3.7
+      env: TOXENV=py36-django20
+    - python: 3.7
+      env: TOXENV=py36-django21
+    - python: 3.7
+      env: TOXENV=py36-django22
+    - python: 3.7
+      env: TOXENV=py36-django30
+
+    # Python 3.8
+    - python: 3.8
+      env: TOXENV=py36-django18
+    - python: 3.8
+      env: TOXENV=py36-django19
+    - python: 3.8
+      env: TOXENV=py36-django110
+    - python: 3.8
+      env: TOXENV=py36-django111
+    - python: 3.8
+      env: TOXENV=py36-django20
+    - python: 3.8
+      env: TOXENV=py36-django21
+    - python: 3.8
+      env: TOXENV=py36-django22
+    - python: 3.8
+      env: TOXENV=py36-django30
+
+    # PyPy
     - python: pypy
-      env: TOXENV=pypy-django18
+      env: TOXENV=pypy3-django18
     - python: pypy
-      env: TOXENV=pypy-django19
+      env: TOXENV=pypy3-django19
     - python: pypy
-      env: TOXENV=pypy-django110
+      env: TOXENV=pypy3-django110
     - python: pypy
-      env: TOXENV=pypy-django111
+      env: TOXENV=pypy3-django111
+    - python: pypy
+      env: TOXENV=pypy3-django20
+    - python: pypy
+      env: TOXENV=pypy3-django21
+    - python: pypy
+      env: TOXENV=pypy3-django22
+
+    # PyPy 3
+    - python: pypy3
+      env: TOXENV=pypy3-django18
+    - python: pypy3
+      env: TOXENV=pypy3-django19
+    - python: pypy3
+      env: TOXENV=pypy3-django110
+    - python: pypy3
+      env: TOXENV=pypy3-django111
+    - python: pypy3
+      env: TOXENV=pypy3-django20
+    - python: pypy3
+      env: TOXENV=pypy3-django21
+    - python: pypy3
+      env: TOXENV=pypy3-django22
+    - python: pypy3
+      env: TOXENV=pypy3-django30
 
 before_install:
   - "wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz"
@@ -57,9 +117,7 @@ install:
   - pip install Django==1.10
   - pip install -r requirements/test.txt
   - pip install -r requirements/docs.txt
-  # TODO: Switch over to pylint v2.0.0 when it becomes available - see circle.yml for further changes
-  - pip install git+https://github.com/PyCQA/pylint.git
-  - pip install git+https://github.com/PyCQA/astroid.git
+  - pip install pylint
 
 script:
   - py.test --cov=django_pdfkit

--- a/pylintrc
+++ b/pylintrc
@@ -4,7 +4,8 @@ max-line-length=140
 [MESSAGES CONTROL]
 
 disable=
-    missing-docstring
+    missing-docstring,
+    no-else-return,
 
 [REPORTS]
 

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ except ImportError:
     from setuptools.command.test import test              # noqa
     is_setuptools = False
 
-import os
-import sys
 import codecs
+import os
+import re
+import sys
 
 NAME = 'django-pdfkit'
 entrypoints = {}
@@ -28,10 +29,14 @@ extra = {}
 classes = """
     Development Status :: 4 - Beta
     Framework :: Django
-    Framework :: Django :: 1.6
-    Framework :: Django :: 1.7
     Framework :: Django :: 1.8
     Framework :: Django :: 1.9
+    Framework :: Django :: 1.10
+    Framework :: Django :: 1.11
+    Framework :: Django :: 2.0
+    Framework :: Django :: 2.1
+    Framework :: Django :: 2.2
+    Framework :: Django :: 3.0
     License :: OSI Approved :: MIT License
     Topic :: Communications
     Topic :: Internet :: WWW/HTTP
@@ -39,12 +44,11 @@ classes = """
     Topic :: Software Development :: Libraries :: Python Modules
     Intended Audience :: Developers
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent
@@ -56,7 +60,6 @@ classifiers = [s.strip() for s in classes.split('\n') if s]
 
 # -*- Distribution Meta -*-
 
-import re
 re_meta = re.compile(r'__(\w+?)__\s*=\s*(.*)')
 re_vers = re.compile(r'VERSION\s*=.*?\((.*?)\)')
 re_doc = re.compile(r'^"""(.+?)"""')

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py{27,34,35,py}-django{18,19,110,111}
-    py{35}-django{111}
+    pypy-django{18,19,110,111}
+    py{35,36,37,38,py3}-django{18,19,110,111,20,21,22}
+    py{36,37,38,py3}-django30
 
 [testenv]
 sitepackages = False
@@ -12,6 +13,10 @@ deps =
     -r{toxinidir}/requirements/test.txt
     git+https://github.com/PyCQA/pylint.git
     git+https://github.com/PyCQA/astroid.git
+    django30: Django>=3.0,<3.1
+    django22: Django>=2.2,<3.0
+    django21: Django>=2.1,<2.2
+    django20: Django>=2.0,<2.1
     django111: Django>=1.11,<1.12
     django110: Django>=1.10,<1.11
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
Adding official support for Django up to 3.0, Python up to 3.8 and PyPy3. At the same time, dropping support for Python < 3.5.